### PR TITLE
🛡️ Sentinel: Prevent information leakage in ErrorBoundary

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** External links were missing `noopener` in the `rel` attribute (specifically the Groq console link).
 **Learning:** While modern browsers often default to `noopener` for `target="_blank"`, explicitly including it with `noreferrer` is a best practice for defense-in-depth and privacy.
 **Prevention:** Use `rel="noopener noreferrer"` for all external links.
+
+## 2025-05-20 - Prevented Information Leakage in Error Boundary
+**Vulnerability:** The global `ErrorBoundary` was displaying raw error messages to users. In production, this could expose sensitive internal details about the application's state, stack traces (if included in message), or environment.
+**Learning:** Error boundaries are great for resilience but must be environment-aware to avoid over-sharing during failures.
+**Prevention:** Use `import.meta.env.DEV` to conditionally show detailed errors in development and generic, safe messages in production.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -35,7 +35,9 @@ export class ErrorBoundary extends Component<Props, State> {
 					<Stack align="center" gap="md">
 						<Title order={2}>Something went wrong</Title>
 						<Text c="dimmed" size="sm" maw={400} ta="center">
-							{this.state.error?.message || "An unexpected error occurred"}
+							{import.meta.env.DEV
+								? this.state.error?.message || "An unexpected error occurred"
+								: "An unexpected error occurred. Please try again later."}
 						</Text>
 						<Button onClick={this.handleReset}>Try Again</Button>
 					</Stack>


### PR DESCRIPTION
The global `ErrorBoundary` was modified to use `import.meta.env.DEV` to conditionally render the error message. In development, the full error message is displayed to assist with debugging. In production, a generic, user-friendly message is displayed to prevent the exposure of internal system details, following security best practices for error handling (CWE-209).

---
*PR created automatically by Jules for task [5374592305909613106](https://jules.google.com/task/5374592305909613106) started by @moodynooby*