### PR TITLE
🛡️ Sentinel: mask raw error messages in production

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -35,7 +35,9 @@ export class ErrorBoundary extends Component<Props, State> {
 					<Stack align="center" gap="md">
 						<Title order={2}>Something went wrong</Title>
 						<Text c="dimmed" size="sm" maw={400} ta="center">
-							{this.state.error?.message || "An unexpected error occurred"}
+							{import.meta.env.DEV
+								? this.state.error?.message || "An unexpected error occurred"
+								: "An unexpected error occurred while rendering this component."}
 						</Text>
 						<Button onClick={this.handleReset}>Try Again</Button>
 					</Stack>

--- a/src/hooks/useAiGroq.ts
+++ b/src/hooks/useAiGroq.ts
@@ -48,9 +48,13 @@ export const useAiGroq = (apiKey: string) => {
 				return text;
 			} catch (err) {
 				if (!mountedRef.current || controller.signal.aborted) return null;
-				console.error("Groq API Error:", err);
 				const errorMessage = err instanceof Error ? err.message : String(err);
-				setError(errorMessage);
+				if (import.meta.env.DEV) {
+					console.error("Groq API Error:", err);
+					setError(errorMessage);
+				} else {
+					setError("Failed to generate content. Please try again later.");
+				}
 				return null;
 			} finally {
 				if (mountedRef.current && !controller.signal.aborted) {


### PR DESCRIPTION
This PR implements a security enhancement by masking raw error messages in production. 

Specifically:
- **`ErrorBoundary.tsx`**: Updated to show a generic error message in production instead of the raw error message/stack trace.
- **`useAiGroq.ts`**: Updated the AI generation hook to suppress detailed API error logging and display a generic "Failed to generate content" message to the user in production.

These changes ensure that sensitive internal details are not exposed to users if an unexpected error occurs or if the Groq API returns an error, following the principle of secure error handling.

---
*PR created automatically by Jules for task [16512930891950998809](https://jules.google.com/task/16512930891950998809) started by @moodynooby*