### PR TITLE
🛡️ Sentinel: Fix XSS vulnerability in plain text file import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import TodoPage from "@/pages/TodoPage";
 import type { ExcalidrawData } from "@/types/sync";
 import type { Filter, ParsedTodoContent, Task } from "@/types/todo";
 import { getToday } from "@/utils/dateUtils";
+import { escapeHtml } from "@/utils/html";
 import { parseTodoContent } from "@/utils/todoParser";
 
 const ExcalidrawPage = lazy(() => import("@/pages/ExcalidrawPage"));
@@ -81,8 +82,14 @@ function AppContent({ activeFilter, onFilterChange }: AppContentProps) {
 		if (!file) return;
 		const reader = new FileReader();
 		reader.onload = (ev) => {
-			const result = ev.target?.result;
+			let result = ev.target?.result;
 			if (typeof result !== "string") return;
+
+			// Escape HTML if importing a plain text file to prevent XSS
+			if (file.name.toLowerCase().endsWith(".txt")) {
+				result = escapeHtml(result);
+			}
+
 			handleFileLoaded(result);
 		};
 		reader.readAsText(file);


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in plain text file import

### 🚨 Severity
HIGH

### 💡 Vulnerability
User-provided plain text files (.txt) were being loaded into the TipTap editor (configured with Markdown) without escaping. This allowed an attacker to execute arbitrary JavaScript if a user opened a specially crafted .txt file containing HTML/Script tags.

### 🎯 Impact
If a user imports a malicious .txt file, arbitrary JavaScript could be executed in the context of their session, potentially leading to data theft or unauthorized actions.

### 🔧 Fix
Updated `src/App.tsx` to use the `escapeHtml` utility when importing `.txt` files. This ensures that any HTML characters are converted to their entity equivalents before the content is passed to the Markdown parser.

### ✅ Verification
- Ran `pnpm check` to ensure no linting or type errors.
- Verified that `escapeHtml` correctly handles special characters.
- Confirmed the logic in `handleFileChange` correctly targets `.txt` files.

---
*PR created automatically by Jules for task [1752768814486791319](https://jules.google.com/task/1752768814486791319) started by @moodynooby*